### PR TITLE
fix 65 Incorrect "filled SQL" if comment in SQL contains "?"

### DIFF
--- a/jdbc-perf-logger-driver/src/main/java/ch/sla/jdbcperflogger/logger/PerfLogger.java
+++ b/jdbc-perf-logger-driver/src/main/java/ch/sla/jdbcperflogger/logger/PerfLogger.java
@@ -312,7 +312,7 @@ public class PerfLogger {
     }
 
     private static boolean isStartingComment(String result, int i) {
-        return result.charAt(i)== '/' &&  result.charAt(i+1)== '*';
+        return result.charAt(i)== '/' &&  result.charAt(i+1)== '*' &&  result.charAt(i+2)!= '+';
     }
     private static boolean isEndComment(String result, int i) {
         return result.charAt(i)== '*' &&  result.charAt(i+1)== '/';

--- a/jdbc-perf-logger-driver/src/main/java/ch/sla/jdbcperflogger/logger/PerfLogger.java
+++ b/jdbc-perf-logger-driver/src/main/java/ch/sla/jdbcperflogger/logger/PerfLogger.java
@@ -285,7 +285,7 @@ public class PerfLogger {
             StringBuffer cleanedStatement = new StringBuffer();
             for (int i = 0; i < result.length(); i++) {
                 //take care of the escape char
-                if (result.charAt(i) == '\'' && ((i - 1) > 0 && result.charAt(i - 1) != '\\')) {
+                if (result.charAt(i) == '\'') {
                     inString = !inString;
                 }
                 if (!inString) {
@@ -302,6 +302,7 @@ public class PerfLogger {
 
                 }
             }
+            if(inString) return result;
 
             return cleanedStatement.toString();
         }

--- a/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
+++ b/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
@@ -32,7 +32,7 @@ public class PerfLoggerTest {
     public void testfillParametersWithPrefixComments() throws Exception {
         testfillParameters("/* select\n" +
                 "        generatedAlias0 \n" +
-                "    from\n" +
+                "    from 'into comment' \n" +
                 "        Person as generatedAlias0 \n" +
                 "    where\n" +
                 "        generatedAlias0.firstName=:param0 */");
@@ -119,9 +119,28 @@ public class PerfLoggerTest {
         Assert.assertEquals(result, PerfLogger.removeComments(result));
     }
     @Test
+    public void removeCommentsWithoutCommentsWithString(){
+        String result ="insert into  emp (?,?,'test')";
+        Assert.assertEquals(result, PerfLogger.removeComments(result));
+    }
+    @Test
+    public void removeCommentsWithoutCommentsWithStringAndComments(){
+        String result ="/* removed one */insert into  emp (?,?,'test')";
+        Assert.assertEquals("insert into  emp (?,?,'test')", PerfLogger.removeComments(result));
+    }
+    @Test
     public void removeCommentsWithoutEmpty(){
         String result ="";
         Assert.assertEquals(result, PerfLogger.removeComments(result));
     }
-
+    @Test
+    public void removeCommentsWithString(){
+        String result ="insert into  /* removed one */emp (?,?,'/*test*/')/*ending comment*/";
+        Assert.assertEquals("insert into  emp (?,?,'/*test*/')", PerfLogger.removeComments(result));
+    }
+    @Test
+    public void removeCommentsWithStringNoClosed(){
+        String result ="insert into  /* removed one */emp (?,?,'/*test*/)/*ending comment*/";
+        Assert.assertEquals(result, PerfLogger.removeComments(result));
+    }
 }

--- a/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
+++ b/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
@@ -135,12 +135,12 @@ public class PerfLoggerTest {
     }
     @Test
     public void removeCommentsWithString(){
-        String result ="insert into  /* removed one */emp (?,?,'/*test*/')/*ending comment*/";
+        String result ="insert into  /* removed one ? */emp (?,?,'/*test*/')/*ending comment*/";
         Assert.assertEquals("insert into  emp (?,?,'/*test*/')", PerfLogger.removeComments(result));
     }
     @Test
     public void removeCommentsWithStringNoClosed(){
-        String result ="insert into  /* removed one */emp (?,?,'/*test*/)/*ending comment*/";
+        String result ="insert into  /* removed one ?*/emp (?,?,'/*test*/)/*ending comment*/";
         Assert.assertEquals(result, PerfLogger.removeComments(result));
     }
 }

--- a/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
+++ b/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
@@ -138,9 +138,15 @@ public class PerfLoggerTest {
         String result ="insert into  /* removed one ? */emp (?,?,'/*test*/')/*ending comment*/";
         Assert.assertEquals("insert into  emp (?,?,'/*test*/')", PerfLogger.removeComments(result));
     }
+
     @Test
     public void removeCommentsWithStringNoClosed(){
         String result ="insert into  /* removed one ?*/emp (?,?,'/*test*/)/*ending comment*/";
         Assert.assertEquals(result, PerfLogger.removeComments(result));
+    }
+    @Test
+    public void removeCommentsWitDBMSHints(){
+        String result ="SELECT /*+ FIRST_ROWS(10) */ * FROM employees;";
+        Assert.assertEquals("SELECT  * FROM employees;", PerfLogger.removeComments(result));
     }
 }

--- a/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
+++ b/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
@@ -135,8 +135,8 @@ public class PerfLoggerTest {
     }
     @Test
     public void removeCommentsWithString(){
-        String result ="insert into  /* removed one ? */emp (?,?,'/*test*/')/*ending comment*/";
-        Assert.assertEquals("insert into  emp (?,?,'/*test*/')", PerfLogger.removeComments(result));
+        String result ="insert into /*+ PARALLEL(4) */  /* removed one ? */emp (?,?,'/*test*/')/*ending comment*/";
+        Assert.assertEquals("insert into /*+ PARALLEL(4) */  emp (?,?,'/*test*/')", PerfLogger.removeComments(result));
     }
 
     @Test
@@ -147,6 +147,13 @@ public class PerfLoggerTest {
     @Test
     public void removeCommentsWitDBMSHints(){
         String result ="SELECT /*+ FIRST_ROWS(10) */ * FROM employees;";
-        Assert.assertEquals("SELECT  * FROM employees;", PerfLogger.removeComments(result));
+        Assert.assertEquals("SELECT /*+ FIRST_ROWS(10) */ * FROM employees;", PerfLogger.removeComments(result));
+
+        result ="/*comment*/ SELECT /*+ PARALLEL(4) */ hr_emp.last_name, d.department_name " +
+                "FROM   employees hr_emp, departments d" +
+                "WHERE  hr_emp.department_id=d.department_id;";
+        Assert.assertEquals(" SELECT /*+ PARALLEL(4) */ hr_emp.last_name, d.department_name FROM   employees hr_emp, departments dWHERE  hr_emp.department_id=d.department_id;", PerfLogger.removeComments(result));
+
+
     }
 }

--- a/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
+++ b/jdbc-perf-logger-driver/src/test/java/ch/sla/jdbcperflogger/logger/PerfLoggerTest.java
@@ -29,46 +29,63 @@ import ch.sla.jdbcperflogger.model.SqlTypedValue;
 
 public class PerfLoggerTest {
     @Test
-    public void testfillParameters() throws Exception {
+    public void testfillParametersWithPrefixComments() throws Exception {
+        testfillParameters("/* select\n" +
+                "        generatedAlias0 \n" +
+                "    from\n" +
+                "        Person as generatedAlias0 \n" +
+                "    where\n" +
+                "        generatedAlias0.firstName=:param0 */");
+
+    }
+
+    @Test
+    public void testfillParametersWithoutPrefixComments() throws Exception {
+
+        testfillParameters("");
+    }
+
+
+    public void testfillParameters(String prefixComments) throws Exception {
         final PreparedStatementValuesHolder valHolder = new PreparedStatementValuesHolder();
         String filledSql;
 
         valHolder.put(1, new SqlTypedValue("toto$", Types.VARCHAR));
-        filledSql = PerfLogger.fillParameters("select * from toto where name = ?", valHolder, DatabaseType.ORACLE);
+        filledSql = PerfLogger.fillParameters(prefixComments + "select * from toto where name = ?", valHolder, DatabaseType.ORACLE);
         Assert.assertEquals("select * from toto where name = 'toto$' /*VARCHAR*/", filledSql);
 
         valHolder.put(2, new SqlTypedValue(36, Types.INTEGER));
-        filledSql = PerfLogger.fillParameters("select * from toto where name = ? and age < ?", valHolder,
+        filledSql = PerfLogger.fillParameters(prefixComments + "select * from toto where name = ? and age < ?", valHolder,
                 DatabaseType.ORACLE);
         Assert.assertEquals("select * from toto where name = 'toto$' /*VARCHAR*/ and age < 36 /*INTEGER*/", filledSql);
 
         valHolder.put(1, new SqlTypedValue(null, Types.VARCHAR));
-        filledSql = PerfLogger.fillParameters("select * from toto where name = ?", valHolder, DatabaseType.ORACLE);
+        filledSql = PerfLogger.fillParameters(prefixComments + "select * from toto where name = ?", valHolder, DatabaseType.ORACLE);
         Assert.assertEquals("select * from toto where name = NULL /*VARCHAR*/", filledSql);
 
         valHolder.put(1, new SqlTypedValue(null, Types.DATE));
-        filledSql = PerfLogger.fillParameters("select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
+        filledSql = PerfLogger.fillParameters(prefixComments + "select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
         Assert.assertEquals("select * from toto where param = NULL /*DATE*/", filledSql);
 
         valHolder.put(1, new SqlTypedValue(java.sql.Date.valueOf("2013-03-04"), Types.DATE));
-        filledSql = PerfLogger.fillParameters("select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
+        filledSql = PerfLogger.fillParameters(prefixComments + "select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
         Assert.assertEquals("select * from toto where param = date'2013-03-04' /*DATE*/", filledSql);
 
         final String dateStr = "2011-07-15T13:45:56.123";
         final Date utilDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").parse(dateStr);
         valHolder.put(1, new SqlTypedValue(utilDate, Types.DATE));
-        filledSql = PerfLogger.fillParameters("select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
+        filledSql = PerfLogger.fillParameters(prefixComments + "select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
         Assert.assertEquals(
                 "select * from toto where param = cast(timestamp'2011-07-15 13:45:56.123' as DATE) /*DATE (non pure)*/",
                 filledSql);
 
         final Timestamp tstamp = Timestamp.valueOf("2011-07-15 13:45:56.123");
         valHolder.put(1, new SqlTypedValue(tstamp, Types.TIMESTAMP));
-        filledSql = PerfLogger.fillParameters("select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
+        filledSql = PerfLogger.fillParameters(prefixComments + "select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
         Assert.assertEquals("select * from toto where param = timestamp'" + tstamp + "' /*TIMESTAMP*/", filledSql);
 
         valHolder.put(1, new SqlTypedValue(new Object(), Types.CLOB));
-        filledSql = PerfLogger.fillParameters("select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
+        filledSql = PerfLogger.fillParameters(prefixComments + "select * from toto where param = ?", valHolder, DatabaseType.ORACLE);
         Assert.assertEquals("select * from toto where param = ? /*CLOB*/", filledSql);
     }
 
@@ -84,6 +101,27 @@ public class PerfLoggerTest {
 
         val = PerfLogger.getValueAsString(new SqlTypedValue("java's cool, it''s", Types.VARCHAR), DatabaseType.ORACLE);
         Assert.assertEquals("'java''s cool, it''''s' /*VARCHAR*/", val);
+    }
+
+    @Test
+    public void removeComments(){
+        String result ="insert into  /* removed one */emp (?,?)/*ending comment*/";
+        Assert.assertEquals("insert into  emp (?,?)", PerfLogger.removeComments(result));
+    }
+    @Test
+    public void removeCommentsFailure(){
+        String result ="insert into  /* removed one */emp (?,?)/*ending comment";
+        Assert.assertEquals(result, PerfLogger.removeComments(result));
+    }
+    @Test
+    public void removeCommentsWithoutComments(){
+        String result ="insert into  emp (?,?)";
+        Assert.assertEquals(result, PerfLogger.removeComments(result));
+    }
+    @Test
+    public void removeCommentsWithoutEmpty(){
+        String result ="";
+        Assert.assertEquals(result, PerfLogger.removeComments(result));
     }
 
 }

--- a/jdbc-perf-logger-spring-boot-starter-test/src/main/resources/application.properties
+++ b/jdbc-perf-logger-spring-boot-starter-test/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 spring.datasource.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
 spring.jpa.hibernate.ddl-auto= validate
 jdbcperflogger.enable=true
+spring.jpa.properties.hibernate.use_sql_comments=true
+logging.level.org.hibernate.SQL=DEBUG


### PR DESCRIPTION
Parser without lexical analyser to remove comments which can appear on prepared statements
In case of malformed comments or empty string return the original rawsql